### PR TITLE
Allow certain packages to be excluded from fixers and the check

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@pnpm/read-project-manifest": "^4.1.1",
     "@pnpm/types": "^8.9.0",
     "commander": "^9.4.1",
+    "json5": "^2.2.1",
     "dependency-path": "^9.2.8",
     "path-exists": "^5.0.0",
     "semver": "^7.3.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ specifiers:
   esbuild: ^0.15.18
   esbuild-node-externals: ^1.5.0
   eslint: ^8.29.0
+  json5: '^2.2.1'
   path-exists: ^5.0.0
   prettier: ^2.8.0
   semver: ^7.3.8
@@ -31,6 +32,7 @@ dependencies:
   '@pnpm/types': 8.9.0
   commander: 9.4.1
   dependency-path: 9.2.8
+  json5: 2.2.1
   path-exists: 5.0.0
   semver: 7.3.8
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+import json5 from "json5";
+
+export interface Config {
+  readonly ignored?: readonly string[];
+}
+
+const CONFIG_FILENAME = "pnpm-deduplicate.json";
+
+export async function readConfig(dir: string): Promise<Config | null> {
+  const configPath = path.join(dir, CONFIG_FILENAME);
+
+  let buf: Buffer;
+  try {
+    buf = await fs.promises.readFile(configPath);
+  } catch (err: unknown) {
+    if ((err as { code?: string }).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+
+  const parsed = json5.parse(buf.toString());
+  assertValidConfig(parsed);
+
+  return parsed;
+}
+
+// This function manually validates the config currently since it's small. If
+// the config ever grows in size, consider using a runtime validation library
+// such as runtypes, ajv, etc.
+export function assertValidConfig(obj: unknown): asserts obj is Config {
+  if (obj == null) {
+    throw new Error("The config object to validate was null or undefined.");
+  }
+
+  const ignored = (obj as Partial<Config>).ignored;
+
+  if (ignored != null && !isArrayOfString(ignored)) {
+    throw new Error(
+      `Expected the ${CONFIG_FILENAME} config "ignored" field to be an array of strings.`
+    );
+  }
+}
+
+function isArrayOfString(obj: unknown): obj is string[] {
+  return (
+    obj != null && Array.isArray(obj) && obj.every((x) => typeof x === "string")
+  );
+}


### PR DESCRIPTION
Hey @ocavue, I'm hoping to roll this tool out to my team. Thanks for making it!

One problem we hit pretty quickly was a significant typing change in a minor version of `@types/lodash`. After `pnpm-deduplicate` removed earlier versions of `@types/lodash` from our monorepo, I spent a few hours attempting to update the existing code for these changes. Finishing this out would be a multi-day effort.

I'd like to require `pnpm-deduplicate check` to pass on CI before builds are merged into the main branch. This would prevent developers from introducing further duplicates in `pnpm-lock.yaml` while we handle the existing duplicates.

Would adding an ignore config for certain dependencies be reasonable?